### PR TITLE
feat: create new home readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,92 @@
 [![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&random=false&width=435&lines=Hello%2C+I'm+João+FullStack+developer%C2%A0%E2%9C%A8)](https://git.io/typing-svg)
 
-[![Linkedin](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jo%C3%A3o-ricardo-martins-ribeiro-4131701a4/) [![Instagram](https://img.shields.io/badge/Instagram-E4405F?style=for-the-badge&logo=instagram&logoColor=white)](https://www.instagram.com/jao.tsx)
+[![Linkedin](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/jo%C3%A3o-ricardo-martins-ribeiro-4131701a4/) [![Instagram](https://img.shields.io/badge/Instagram-E4405F?style=for-the-badge&logo=instagram&logoColor=white)](https://www.instagram.com/jao.tsx) [![GitHub](https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/EngJao89)
 
-<a href="https://github.com/anuraghazra/github-readme-stats"></a>
-  <img 
-    height=250 
-    align="center" 
-    src="https://github-readme-stats.vercel.app/api?username=EngJao89&show_icons=true&theme=dracula" 
-  />
-</a>
-<a href="https://github.com/anuraghazra/convoychat">
-  <img 
-    height=300 
-    align="center" 
-    src="https://github-readme-stats.vercel.app/api/top-langs?username=EngJao89&&layout=donut-vertical&langs_count=8&card_width=320&theme=dracula" 
-  />
-</a>
+## 📊 Estatísticas do GitHub
+
+<table>
+  <tr>
+    <td>
+      <a href="https://github.com/EngJao89">
+      <img src="https://github-readme-activity-graph.vercel.app/graph?username=EngJao89&theme=dracula&hide_border=true"/>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/EngJao89">
+      <img src="https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=EngJao89&theme=dracula"/>
+      </a>
+    </td>
+  </tr>
+</table>
+
+<div align="center">
+  <img src="https://github-trophies.vercel.app/?username=EngJao89&theme=dracula&column=7"/>
+</div>
+
+## 👨‍💻 Sobre Mim
+
+Desenvolvedor FullStack, com experiência em desenvolvimento web e mobile. Sempre em busca de aprender novas tecnologias e melhorar minhas habilidades.
+
+- 🔭 Atualmente trabalhando em projetos FullStack
+- 🌱 Sempre aprendendo novas tecnologias e frameworks
+- 💬 Pergunte-me sobre TypeScript, React, Node.js e desenvolvimento mobile
+- 📫 Como me encontrar: [LinkedIn](https://www.linkedin.com/in/jo%C3%A3o-ricardo-martins-ribeiro-4131701a4/) | [Instagram](https://www.instagram.com/jao.tsx)
 
 ## 🚀 Minhas Skills
 
-<p align="left">
-  <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=typescript,javascript,react,redux,nextjs,vite,angular,nodejs,nestjs,fastapi,express,swift,java,kotlin,gradle,html,css,tailwind,styledcomponents,bootstrap,materialui,vitest,jest,aws,azure,googlecloud,mongodb,postgres,mysql,prisma,sqlite,sequelize,firebase,spring,sentry,webpack" />
-  </a>
-</p>
-
-## 🛠️Ferramentas de desenvolvimento
+### Frontend & Mobile
 
 <p align="left">
   <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=androidstudio,apple,bash,bitbucket,devto,docker,mint,figma,git,githubactions,github,gitlab,idea,linux,npm,postman,ubuntu,stackoverflow,vercel,vscode,yarn" />
+    <img src="https://skillicons.dev/icons?i=typescript,javascript,react,redux,nextjs,vite,angular,html,css,tailwind,styledcomponents,bootstrap,materialui,swift,java,kotlin" alt="Frontend e Mobile Technologies" />
   </a>
 </p>
+
+### Backend
+
+<p align="left">
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=nodejs,nestjs,fastapi,express,spring,gradle" alt="Backend Technologies" />
+  </a>
+</p>
+
+### Banco de Dados
+
+<p align="left">
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=mongodb,postgres,mysql,prisma,sqlite,sequelize,firebase" alt="Database Technologies" />
+  </a>
+</p>
+
+### Cloud & DevOps
+
+<p align="left">
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=aws,azure,googlecloud,docker,githubactions" alt="Cloud e DevOps Technologies" />
+  </a>
+</p>
+
+### Testes & Ferramentas
+
+<p align="left">
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=vitest,jest,sentry,webpack" alt="Testing e Tools" />
+  </a>
+</p>
+
+## 🛠️ Ferramentas de Desenvolvimento
+
+<p align="left">
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=androidstudio,apple,bash,bitbucket,devto,figma,git,github,gitlab,idea,linux,npm,postman,ubuntu,stackoverflow,vercel,vscode,yarn" alt="Development Tools" />
+  </a>
+</p>
+
+## 📈 Contribuições
+
+<div align="center">
+  <img
+    src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=EngJao89&theme=dracula"
+    alt="Detalhes do perfil"
+  />
+</div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Revamps README with social/GitHub badges, detailed GitHub stats and trophies, reorganized skills sections, dev tools, and contributions summary while removing old stats cards.
> 
> - **README**:
>   - **Profile enhancements**:
>     - Add GitHub badge alongside LinkedIn/Instagram.
>     - Introduce GitHub activity graph, most-commit language card, and trophies.
>     - Add About Me section with contact links.
>   - **Skills reorganization**:
>     - Split into Frontend & Mobile, Backend, Banco de Dados, Cloud & DevOps, and Testes & Ferramentas using `skillicons`.
>   - **Tools & Contributions**:
>     - Add Development Tools section.
>     - Add Contributions profile-details card.
>   - **Cleanup**:
>     - Remove previous GitHub readme stats and top-langs images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54c930eb259576536ad0be83969821f0e2d25fbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->