### PR TITLE
change most language used stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@
     </td>
     <td>
       <a href="https://github.com/EngJao89">
-      <img src="https://github-profile-summary-cards.vercel.app/api/cards/most-commit-language?username=EngJao89&theme=dracula"/>
+      <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=EngJao89&layout=donut-vertical&theme=dracula&hide_"/>
       </a>
     </td>
   </tr>
 </table>
-
-<div align="center">
-  <img src="https://github-trophies.vercel.app/?username=EngJao89&theme=dracula&column=7"/>
-</div>
 
 ## 👨‍💻 Sobre Mim
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refreshes README GitHub stats by switching to the top-langs donut-vertical card and removing the trophies section.
> 
> - **README** (`README.md`):
>   - Replace language stats card from `github-profile-summary-cards` with `github-readme-stats` top-langs (donut-vertical, `dracula`).
>   - Remove GitHub trophies section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9bf4a02acd84d96811970f5f444c7b693a3298b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->